### PR TITLE
Merge new `Draw` api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ wrap = []
 [dev-dependencies]
 softbuffer = "0.3.0"
 winit = "0.28.6"
+minifb = "0.27.0"

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -19,7 +19,7 @@ mod image {
 }
 use image::IMAGE;
 
-use framebrush::{Canvas, Drawable};
+use framebrush::{Canvas, Draw};
 use minifb::{Window, WindowOptions};
 
 const DEFAULT_WIDTH: usize = 800;
@@ -38,7 +38,7 @@ impl<T: AsRef<[u32]>> ImageSource<T> {
             (target_width, target_height),
             (self.width, self.data.as_ref().len() / self.width),
         );
-        self.draw(&mut canvas, 0, 0, &framebrush::WHITE);
+        self.draw(&mut canvas, 0, 0);
         ImageSource {
             data: res,
             width: target_width,
@@ -46,23 +46,15 @@ impl<T: AsRef<[u32]>> ImageSource<T> {
     }
 }
 
-impl<T: AsRef<[u32]>> Drawable<u32, framebrush::RGBu32> for ImageSource<T> {
-    fn draw(
-        &self,
-        canvas: &mut Canvas<u32>,
-        start_x: i32,
-        start_y: i32,
-        _color: &framebrush::RGBu32, // Could be used to add a tint to the image
-    ) {
+impl<T: AsRef<[u32]>> Draw for ImageSource<T> {
+    type T = u32;
+    fn draw(&self, canvas: &mut Canvas<u32>, start_x: i32, start_y: i32) -> u32 {
         for (y, strip) in self.data.as_ref().chunks(self.width).enumerate() {
             for (x, c) in strip.iter().enumerate() {
-                canvas.put(
-                    start_x + x as i32,
-                    start_y + y as i32,
-                    &framebrush::RGBu32::Pixel(*c),
-                );
+                canvas.put(start_x + x as i32, start_y + y as i32, *c);
             }
         }
+        0
     }
 }
 
@@ -94,7 +86,7 @@ fn main() {
         // Begin drawing
         let mut canvas = Canvas::new(&mut buf, (width, height), (DEFAULT_WIDTH, DEFAULT_HEIGHT));
         canvas.fill(0);
-        canvas.draw(100, 100, &image_render, &framebrush::WHITE);
+        canvas.draw(100, 100, &image_render);
 
         // End drawing
         window.update_with_buffer(&buf, width, height).unwrap();

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,0 +1,102 @@
+mod image {
+    const BLACK: u32 = 0;
+    const RED: u32 = 0xff0000;
+    const GREEN: u32 = 0x00ff00;
+    const BLUE: u32 = 0x0000ff;
+    const WHITE: u32 = 0xffffff;
+
+    #[rustfmt::skip]
+    pub const IMAGE: [u32; 64] = [
+        RED,   RED, BLUE, RED, RED,   RED,   RED,   BLACK,
+        WHITE, RED, RED,  RED, RED,   RED,   BLACK, RED,
+        WHITE, RED, RED,  RED, GREEN, GREEN, RED,   RED,
+        WHITE, RED, RED,  RED, GREEN, RED,   RED,   RED,
+        WHITE, RED, RED,  RED, GREEN, RED,   RED,   RED,
+        WHITE, RED, BLUE, RED, RED,   RED,   RED,   RED,
+        WHITE, RED, RED,  RED, RED,   RED,   RED,   BLUE,
+        WHITE, RED, RED,  RED, RED,   RED,   BLUE,  GREEN,
+    ];
+}
+use image::IMAGE;
+
+use framebrush::{Canvas, Drawable};
+use minifb::{Window, WindowOptions};
+
+const DEFAULT_WIDTH: usize = 800;
+const DEFAULT_HEIGHT: usize = 600;
+
+struct ImageSource<T: AsRef<[u32]>> {
+    data: T,
+    width: usize,
+}
+
+impl<T: AsRef<[u32]>> ImageSource<T> {
+    fn render(&self, target_width: usize, target_height: usize) -> ImageSource<Vec<u32>> {
+        let mut res = vec![0; target_width * target_height];
+        let mut canvas = Canvas::new(
+            &mut res,
+            (target_width, target_height),
+            (self.width, self.data.as_ref().len() / self.width),
+        );
+        self.draw(&mut canvas, 0, 0, &framebrush::WHITE);
+        ImageSource {
+            data: res,
+            width: target_width,
+        }
+    }
+}
+
+impl<T: AsRef<[u32]>> Drawable<u32, framebrush::RGBu32> for ImageSource<T> {
+    fn draw(
+        &self,
+        canvas: &mut Canvas<u32>,
+        start_x: i32,
+        start_y: i32,
+        _color: &framebrush::RGBu32, // Could be used to add a tint to the image
+    ) {
+        for (y, strip) in self.data.as_ref().chunks(self.width).enumerate() {
+            for (x, c) in strip.iter().enumerate() {
+                canvas.put(
+                    start_x + x as i32,
+                    start_y + y as i32,
+                    &framebrush::RGBu32::Pixel(*c),
+                );
+            }
+        }
+    }
+}
+
+fn main() {
+    let mut buf = vec![0 as u32; DEFAULT_WIDTH * DEFAULT_HEIGHT];
+
+    let mut window = Window::new(
+        "Image Example",
+        DEFAULT_WIDTH,
+        DEFAULT_HEIGHT,
+        WindowOptions {
+            resize: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let image_render = ImageSource {
+        data: IMAGE,
+        width: 8,
+    }
+    .render(200, 300);
+
+    window.set_target_fps(144);
+    while window.is_open() {
+        let (width, height) = window.get_size();
+        buf.resize(width * height, 0);
+
+        // Begin drawing
+        let mut canvas = Canvas::new(&mut buf, (width, height), (DEFAULT_WIDTH, DEFAULT_HEIGHT));
+        canvas.fill(0);
+        canvas.draw(100, 100, &image_render, &framebrush::WHITE);
+
+        // End drawing
+        window.update_with_buffer(&buf, width, height).unwrap();
+    }
+}

--- a/examples/rgba.rs
+++ b/examples/rgba.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use framebrush::{Canvas, Color};
+use framebrush::{Canvas, Draw};
 use winit::{
     dpi::LogicalSize,
     event::{Event, WindowEvent},
@@ -19,9 +19,10 @@ fn rgba(r: f32, g: f32, b: f32, a: f32) -> Rgba {
     Rgba { r, g, b, a }
 }
 
-impl Color<u32> for Rgba {
-    fn pixel(&self, buf: &mut [u32], idx: usize) -> u32 {
-        let prev = buf[idx];
+impl Draw for Rgba {
+    type T = u32;
+    fn draw(&self, canvas: &mut Canvas<'_, Self::T>, x: i32, y: i32) -> Self::T {
+        let prev = *canvas.get(x as usize, y as usize);
         let prev = Rgba {
             r: (prev >> 16) as f32 / 255.,
             g: ((prev >> 8) & 0xff) as f32 / 255.,

--- a/examples/simple_terminal.rs
+++ b/examples/simple_terminal.rs
@@ -1,18 +1,20 @@
-use framebrush::{Canvas, Color};
+use framebrush::{Canvas, Draw};
 
 const BUF_WIDTH: usize = 32;
 const BUF_HEIGHT: usize = 32;
 
-enum CharColor {
+enum Char {
     HashTag,
     AtSign,
 }
 
-impl Color<char> for CharColor {
-    fn pixel(&self, _buf: &mut [char], _idx: usize) -> char {
+impl Draw for Char {
+    type T = char;
+
+    fn draw(&self, _canvas: &mut Canvas<'_, Self::T>, _x: i32, _y: i32) -> Self::T {
         match self {
-            Self::HashTag => '#',
-            Self::AtSign => '@',
+            Char::HashTag => '#',
+            Char::AtSign => '@',
         }
     }
 }
@@ -22,8 +24,8 @@ fn main() {
 
     let mut canvas = Canvas::new(&mut buf, (BUF_WIDTH, BUF_HEIGHT), (BUF_WIDTH, BUF_HEIGHT));
 
-    canvas.rect(0, 0, 5, 5, &CharColor::AtSign);
-    canvas.line(0, 31, 25, 16, &CharColor::HashTag);
+    canvas.rect(0, 0, 5, 5, &Char::AtSign);
+    canvas.line(0, 31, 25, 16, &Char::HashTag);
 
     for y in 0..BUF_HEIGHT {
         let stripe = &buf[(y * BUF_WIDTH)..((y + 1) * BUF_WIDTH)];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,131 @@ pub struct Canvas<'a, T> {
     canvas_size: (usize, usize),
 }
 
+pub trait Drawable<T, C: Color<T>> {
+    fn draw(&self, canvas: &mut Canvas<T>, x: i32, y: i32, color: &C);
+}
+
+pub struct Pixel {}
+
+impl<T: Clone, C: Color<T>> Drawable<T, C> for Pixel {
+    fn draw(&self, canvas: &mut Canvas<T>, x: i32, y: i32, color: &C) {
+        canvas.put(x, y, color);
+    }
+}
+
+pub struct Rect {
+    pub w: usize,
+    pub h: usize,
+}
+
+impl<T, C: Color<T>> Drawable<T, C> for Rect {
+    fn draw(&self, canvas: &mut Canvas<T>, x: i32, y: i32, color: &C) {
+        #[cfg(not(feature = "wrap"))]
+        {
+            let x = {
+                if x <= 0 {
+                    0
+                } else {
+                    x as usize
+                }
+            };
+            let y = {
+                if y <= 0 {
+                    0
+                } else {
+                    y as usize
+                }
+            };
+            for y_idx in round(y as f32 * canvas.ratio.1) as usize {
+                let start =
+                    round(x as f32 * canvas.ratio.0) as usize + y_idx * canvas.surface_size.0;
+                let end = round((x + self.w) as f32 * canvas.ratio.0) as usize
+                    + y_idx * canvas.surface_size.0;
+                for idx in start..end {
+                    if idx < (y_idx + 1) * canvas.surface_size.0 && idx < canvas.buf.len() {
+                        canvas.buf[idx] = color.pixel(canvas.buf, idx);
+                    }
+                }
+            }
+        }
+
+        #[cfg(feature = "wrap")]
+        {
+            let x = modv2(x, canvas.canvas_size.0 as i32) as usize;
+            let y = modv2(y, canvas.canvas_size.1 as i32) as usize;
+            for y_idx in round(y as f32 * canvas.ratio.1) as usize
+                ..round((y + self.h) as f32 * canvas.ratio.1) as usize
+            {
+                for x_idx in round(x as f32 * canvas.ratio.0) as usize
+                    ..round((x + self.w) as f32 * canvas.ratio.0) as usize
+                {
+                    // x_idx and y_idx are `usize` and therefore can't be negative.
+                    let x_idx = x_idx % canvas.surface_size.0;
+                    let y_idx = y_idx % canvas.surface_size.1;
+                    let idx = x_idx + y_idx * canvas.surface_size.0;
+                    if idx < (y_idx + 1) * canvas.surface_size.0 && idx < canvas.buf.len() {
+                        canvas.buf[idx] = color.pixel(canvas.buf, idx);
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct Line {
+    end_x: i32,
+    end_y: i32,
+}
+impl<T: Clone, C: Color<T>> Drawable<T, C> for Line {
+    fn draw(&self, canvas: &mut Canvas<T>, x: i32, y: i32, color: &C) {
+        // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
+        let mut x0 = x;
+        let mut y0 = y;
+        let x1 = self.end_x;
+        let y1 = self.end_y;
+        let dx = (x1 - x0).abs();
+        let sx = {
+            if x0 < x1 {
+                1
+            } else {
+                -1
+            }
+        };
+        let dy = -(y1 - y0).abs();
+        let sy = {
+            if y0 < y1 {
+                1
+            } else {
+                -1
+            }
+        };
+        let mut error = dx + dy;
+
+        loop {
+            canvas.put(x0, y0, color);
+            if x0 == x1 && y0 == y1 {
+                break;
+            }
+            let e2 = 2 * error;
+            if e2 >= dy {
+                if x0 == x1 {
+                    break;
+                }
+                error += dy;
+                x0 += sx;
+            }
+
+            if e2 <= dx {
+                if y0 == y1 {
+                    break;
+                }
+                error += dx;
+                y0 += sy;
+            }
+        }
+    }
+}
+
 fn round(n: f32) -> f32 {
     let nfloor = n as i32 as f32;
     if n - nfloor >= 0.5 {
@@ -63,6 +188,11 @@ impl<'a, T: Clone> Canvas<'a, T> {
         self.buf[idx] = color.pixel(self.buf, idx)
     }
 
+    /// Draws any `Drawable` object
+    pub fn draw<C: Color<T>, D: Drawable<T, C>>(&mut self, x: i32, y: i32, d: &D, c: &C) {
+        d.draw(self, x, y, c);
+    }
+
     /// 'Put's a color to the specified position on the *canvas*
     pub fn put<C: Color<T>>(&mut self, x: i32, y: i32, color: &C) {
         self.rect(x, y, 1, 1, color);
@@ -70,101 +200,20 @@ impl<'a, T: Clone> Canvas<'a, T> {
 
     /// 'Put's a rectangle to the specified position on the *canvas*
     pub fn rect<C: Color<T>>(&mut self, x: i32, y: i32, w: usize, h: usize, color: &C) {
-        #[cfg(not(feature = "wrap"))]
-        {
-            let x = {
-                if x <= 0 {
-                    0
-                } else {
-                    x as usize
-                }
-            };
-            let y = {
-                if y <= 0 {
-                    0
-                } else {
-                    y as usize
-                }
-            };
-            for y_idx in round(y as f32 * self.ratio.1) as usize {
-                let start = round(x as f32 * self.ratio.0) as usize + y_idx * self.surface_size.0;
-                let end =
-                    round((x + w) as f32 * self.ratio.0) as usize + y_idx * self.surface_size.0;
-                for idx in start..end {
-                    if idx < (y_idx + 1) * self.surface_size.0 && idx < self.buf.len() {
-                        self.buf[idx] = color.pixel(self.buf, idx);
-                    }
-                }
-            }
-        }
-
-        #[cfg(feature = "wrap")]
-        {
-            let x = modv2(x, self.canvas_size.0 as i32) as usize;
-            let y = modv2(y, self.canvas_size.1 as i32) as usize;
-            for y_idx in round(y as f32 * self.ratio.1) as usize
-                ..round((y + h) as f32 * self.ratio.1) as usize
-            {
-                for x_idx in round(x as f32 * self.ratio.0) as usize
-                    ..round((x + w) as f32 * self.ratio.0) as usize
-                {
-                    // x_idx and y_idx are `usize` and therefore can't be negative.
-                    let x_idx = x_idx % self.surface_size.0;
-                    let y_idx = y_idx % self.surface_size.1;
-                    let idx = x_idx + y_idx * self.surface_size.0;
-                    if idx < (y_idx + 1) * self.surface_size.0 && idx < self.buf.len() {
-                        self.buf[idx] = color.pixel(self.buf, idx);
-                    }
-                }
-            }
-        }
+        self.draw(x, y, &mut Rect { w, h }, color);
     }
 
     /// Draws a line on the canvas using Bresenham's algorithm (no anti aliasing).
     pub fn line<C: Color<T>>(&mut self, x0: i32, y0: i32, x1: i32, y1: i32, color: &C) {
-        // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
-        let mut x0 = x0;
-        let mut y0 = y0;
-        let dx = (x1 - x0).abs();
-        let sx = {
-            if x0 < x1 {
-                1
-            } else {
-                -1
-            }
-        };
-        let dy = -(y1 - y0).abs();
-        let sy = {
-            if y0 < y1 {
-                1
-            } else {
-                -1
-            }
-        };
-        let mut error = dx + dy;
-
-        loop {
-            self.put(x0, y0, color);
-            if x0 == x1 && y0 == y1 {
-                break;
-            }
-            let e2 = 2 * error;
-            if e2 >= dy {
-                if x0 == x1 {
-                    break;
-                }
-                error += dy;
-                x0 += sx;
-            }
-
-            if e2 <= dx {
-                if y0 == y1 {
-                    break;
-                }
-                error += dx;
-                y0 += sy;
-            }
-        }
+        self.draw(
+            x0,
+            y0,
+            &Line {
+                end_x: x1,
+                end_y: y1,
+            },
+            color,
+        );
     }
 
     /// A method that consumes self and returns the frame buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,12 @@ pub struct Canvas<'a, T> {
     canvas_size: (usize, usize),
 }
 
+// Perhaps instead of having two seperate traits called `Drawable` and `Color`, they could be merged into a single `Color` trait similar to the following:
+/*
+    pub trait Color<T> {
+        fn pixel(&self, canvas: &mut Canvas<'_, T>, x: i32, y: i32) -> T;
+    }
+*/
 pub trait Drawable<T, C: Color<T>> {
     fn draw(&self, canvas: &mut Canvas<T>, x: i32, y: i32, color: &C);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-pub trait Color<T> {
-    fn pixel(&self, buf: &mut [T], index: usize) -> T;
-}
-
 pub struct Canvas<'a, T> {
     ratio: (f32, f32),
     buf: &'a mut [T],
@@ -11,135 +7,9 @@ pub struct Canvas<'a, T> {
     canvas_size: (usize, usize),
 }
 
-// Perhaps instead of having two seperate traits called `Drawable` and `Color`, they could be merged into a single `Color` trait similar to the following:
-/*
-    pub trait Color<T> {
-        fn pixel(&self, canvas: &mut Canvas<'_, T>, x: i32, y: i32) -> T;
-    }
-*/
-pub trait Drawable<T, C: Color<T>> {
-    fn draw(&self, canvas: &mut Canvas<T>, x: i32, y: i32, color: &C);
-}
-
-pub struct Pixel {}
-
-impl<T: Clone, C: Color<T>> Drawable<T, C> for Pixel {
-    fn draw(&self, canvas: &mut Canvas<T>, x: i32, y: i32, color: &C) {
-        canvas.put(x, y, color);
-    }
-}
-
-pub struct Rect {
-    pub w: usize,
-    pub h: usize,
-}
-
-impl<T, C: Color<T>> Drawable<T, C> for Rect {
-    fn draw(&self, canvas: &mut Canvas<T>, x: i32, y: i32, color: &C) {
-        #[cfg(not(feature = "wrap"))]
-        {
-            let x = {
-                if x <= 0 {
-                    0
-                } else {
-                    x as usize
-                }
-            };
-            let y = {
-                if y <= 0 {
-                    0
-                } else {
-                    y as usize
-                }
-            };
-            for y_idx in round(y as f32 * canvas.ratio.1) as usize {
-                let start =
-                    round(x as f32 * canvas.ratio.0) as usize + y_idx * canvas.surface_size.0;
-                let end = round((x + self.w) as f32 * canvas.ratio.0) as usize
-                    + y_idx * canvas.surface_size.0;
-                for idx in start..end {
-                    if idx < (y_idx + 1) * canvas.surface_size.0 && idx < canvas.buf.len() {
-                        canvas.buf[idx] = color.pixel(canvas.buf, idx);
-                    }
-                }
-            }
-        }
-
-        #[cfg(feature = "wrap")]
-        {
-            let x = modv2(x, canvas.canvas_size.0 as i32) as usize;
-            let y = modv2(y, canvas.canvas_size.1 as i32) as usize;
-            for y_idx in round(y as f32 * canvas.ratio.1) as usize
-                ..round((y + self.h) as f32 * canvas.ratio.1) as usize
-            {
-                for x_idx in round(x as f32 * canvas.ratio.0) as usize
-                    ..round((x + self.w) as f32 * canvas.ratio.0) as usize
-                {
-                    // x_idx and y_idx are `usize` and therefore can't be negative.
-                    let x_idx = x_idx % canvas.surface_size.0;
-                    let y_idx = y_idx % canvas.surface_size.1;
-                    let idx = x_idx + y_idx * canvas.surface_size.0;
-                    if idx < (y_idx + 1) * canvas.surface_size.0 && idx < canvas.buf.len() {
-                        canvas.buf[idx] = color.pixel(canvas.buf, idx);
-                    }
-                }
-            }
-        }
-    }
-}
-
-struct Line {
-    end_x: i32,
-    end_y: i32,
-}
-impl<T: Clone, C: Color<T>> Drawable<T, C> for Line {
-    fn draw(&self, canvas: &mut Canvas<T>, x: i32, y: i32, color: &C) {
-        // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
-        let mut x0 = x;
-        let mut y0 = y;
-        let x1 = self.end_x;
-        let y1 = self.end_y;
-        let dx = (x1 - x0).abs();
-        let sx = {
-            if x0 < x1 {
-                1
-            } else {
-                -1
-            }
-        };
-        let dy = -(y1 - y0).abs();
-        let sy = {
-            if y0 < y1 {
-                1
-            } else {
-                -1
-            }
-        };
-        let mut error = dx + dy;
-
-        loop {
-            canvas.put(x0, y0, color);
-            if x0 == x1 && y0 == y1 {
-                break;
-            }
-            let e2 = 2 * error;
-            if e2 >= dy {
-                if x0 == x1 {
-                    break;
-                }
-                error += dy;
-                x0 += sx;
-            }
-
-            if e2 <= dx {
-                if y0 == y1 {
-                    break;
-                }
-                error += dx;
-                y0 += sy;
-            }
-        }
-    }
+pub trait Draw {
+    type T;
+    fn draw(&self, canvas: &mut Canvas<'_, Self::T>, x: i32, y: i32) -> Self::T;
 }
 
 fn round(n: f32) -> f32 {
@@ -178,53 +48,198 @@ impl<'a, T: Clone> Canvas<'a, T> {
         self.buf.fill(val)
     }
 
-    pub fn clear<C: Color<T>>(&mut self, color: C) {
-        let pixel = color.pixel(self.buf, 0);
-        self.buf.fill(pixel)
+    pub fn clear<D: Draw<T = T>>(&mut self, d: &D) {
+        let val = d.draw(self, 0, 0);
+        self.fill(val);
     }
 
     /// Sets a pixel directly in the surface
-    pub fn set_pixel(&mut self, x: usize, y: usize, val: T) {
+    pub fn set(&mut self, x: usize, y: usize, val: T) {
         self.buf[x + y * self.surface_size.0] = val
     }
 
-    /// Sets a pixel directly in the surface
-    pub fn set<C: Color<T>>(&mut self, x: usize, y: usize, color: &C) {
-        let idx = x + y * self.surface_size.0;
-        self.buf[idx] = color.pixel(self.buf, idx)
+    pub fn get(&self, x: usize, y: usize) -> &T {
+        &self.buf[x + y * self.surface_size.0]
+    }
+    pub fn get_mut(&mut self, x: usize, y: usize) -> &mut T {
+        &mut self.buf[x + y * self.surface_size.0]
     }
 
     /// Draws any `Drawable` object
-    pub fn draw<C: Color<T>, D: Drawable<T, C>>(&mut self, x: i32, y: i32, d: &D, c: &C) {
-        d.draw(self, x, y, c);
+    pub fn draw<D: Draw<T = T>>(&mut self, x: i32, y: i32, d: &D) {
+        d.draw(self, x, y);
     }
 
-    /// 'Put's a color to the specified position on the *canvas*
-    pub fn put<C: Color<T>>(&mut self, x: i32, y: i32, color: &C) {
-        self.rect(x, y, 1, 1, color);
+    /// 'Put's a value to the specified position on the *canvas*
+    pub fn put(&mut self, x: i32, y: i32, val: T) {
+        #[cfg(not(feature = "wrap"))]
+        {
+            let x = {
+                if x <= 0 {
+                    0
+                } else {
+                    x as usize
+                }
+            };
+            let y = {
+                if y <= 0 {
+                    0
+                } else {
+                    y as usize
+                }
+            };
+            for y_idx in round(y as f32 * self.ratio.1) as usize
+                ..round((y + 1) as f32 * self.ratio.1) as usize
+            {
+                let start = round(x as f32 * self.ratio.0) as usize + y_idx * self.surface_size.0;
+                let end =
+                    round((x + 1) as f32 * self.ratio.0) as usize + y_idx * self.surface_size.0;
+                for idx in start..end {
+                    if idx < (y_idx + 1) * self.surface_size.0 && idx < self.buf.len() {
+                        self.buf[idx] = val.clone();
+                    }
+                }
+            }
+        }
+
+        #[cfg(feature = "wrap")]
+        {
+            let x = modv2(x, self.canvas_size.0 as i32) as usize;
+            let y = modv2(y, self.canvas_size.1 as i32) as usize;
+            for y_idx in round(y as f32 * self.ratio.1) as usize
+                ..round((y + 1) as f32 * self.ratio.1) as usize
+            {
+                for x_idx in round(x as f32 * self.ratio.0) as usize
+                    ..round((x + 1) as f32 * self.ratio.0) as usize
+                {
+                    // x_idx and y_idx are `usize` and therefore can't be negative.
+                    let x_idx = x_idx % self.surface_size.0;
+                    let y_idx = y_idx % self.surface_size.1;
+                    let idx = x_idx + y_idx * self.surface_size.0;
+                    if idx < (y_idx + 1) * self.surface_size.0 && idx < self.buf.len() {
+                        self.set(x_idx, y_idx, val.clone());
+                    }
+                }
+            }
+        }
     }
 
     /// 'Put's a rectangle to the specified position on the *canvas*
-    pub fn rect<C: Color<T>>(&mut self, x: i32, y: i32, w: usize, h: usize, color: &C) {
-        self.draw(x, y, &mut Rect { w, h }, color);
+    pub fn rect<D: Draw<T = T>>(&mut self, x: i32, y: i32, w: usize, h: usize, d: &D) {
+        self.draw(x, y, &Rect { w, h, d });
     }
 
     /// Draws a line on the canvas using Bresenham's algorithm (no anti aliasing).
-    pub fn line<C: Color<T>>(&mut self, x0: i32, y0: i32, x1: i32, y1: i32, color: &C) {
+    pub fn line<D: Draw<T = T>>(&mut self, x0: i32, y0: i32, x1: i32, y1: i32, d: &D) {
         self.draw(
             x0,
             y0,
             &Line {
                 end_x: x1,
                 end_y: y1,
+                d,
             },
-            color,
         );
     }
 
     /// A method that consumes self and returns the frame buffer
     pub fn finish(self) -> &'a mut [T] {
         self.buf
+    }
+}
+
+pub struct Pixel<T: Clone>(T);
+impl<P: Clone> Draw for Pixel<P> {
+    type T = P;
+
+    fn draw(&self, canvas: &mut Canvas<'_, Self::T>, x: i32, y: i32) -> Self::T {
+        canvas.put(x, y, self.0.clone());
+        self.0.clone()
+    }
+}
+
+pub struct Rect<'a, D: Draw> {
+    pub w: usize,
+    pub h: usize,
+    pub d: &'a D,
+}
+
+impl<P: Clone, D: Draw<T = P>> Draw for Rect<'_, D> {
+    type T = P;
+
+    fn draw(&self, canvas: &mut Canvas<'_, Self::T>, x: i32, y: i32) -> Self::T {
+        let mut y_counter = y;
+        let val = self.d.draw(canvas, x, y);
+        for _ in 0..self.h {
+            let mut x_counter = x;
+            for _ in 0..self.w {
+                canvas.put(x_counter, y_counter, val.clone());
+                x_counter += 1;
+            }
+            y_counter += 1;
+        }
+        val
+    }
+}
+
+struct Line<'a, D: Draw> {
+    end_x: i32,
+    end_y: i32,
+    pub d: &'a D,
+}
+
+impl<P: Clone, D: Draw<T = P>> Draw for Line<'_, D> {
+    type T = P;
+
+    fn draw(&self, canvas: &mut Canvas<'_, Self::T>, x: i32, y: i32) -> Self::T {
+        let val = self.d.draw(canvas, x, y);
+
+        let mut x0 = x;
+        let mut y0 = y;
+        let x1 = self.end_x;
+        let y1 = self.end_y;
+        let dx = (x1 - x0).abs();
+        let sx = {
+            if x0 < x1 {
+                1
+            } else {
+                -1
+            }
+        };
+        let dy = -(y1 - y0).abs();
+        let sy = {
+            if y0 < y1 {
+                1
+            } else {
+                -1
+            }
+        };
+        let mut error = dx + dy;
+
+        loop {
+            canvas.put(x0, y0, val.clone());
+            if x0 == x1 && y0 == y1 {
+                break;
+            }
+            let e2 = 2 * error;
+            if e2 >= dy {
+                if x0 == x1 {
+                    break;
+                }
+                error += dy;
+                x0 += sx;
+            }
+
+            if e2 <= dx {
+                if y0 == y1 {
+                    break;
+                }
+                error += dx;
+                y0 += sy;
+            }
+        }
+
+        val
     }
 }
 
@@ -241,13 +256,16 @@ pub const BLUE: RGBu32 = RGBu32::Pixel(0x0000ff);
 pub const WHITE: RGBu32 = RGBu32::Pixel(0xffffff);
 pub const YELLOW: RGBu32 = RGBu32::Pixel(0xffff00);
 
-impl Color<u32> for RGBu32 {
-    fn pixel(&self, _buf: &mut [u32], _idx: usize) -> u32 {
-        match self {
+impl Draw for RGBu32 {
+    type T = u32;
+    fn draw(&self, canvas: &mut Canvas<'_, u32>, x: i32, y: i32) -> u32 {
+        let val = match self {
             Self::Rgb(red, green, blue) => {
                 ((*red as u32) << 16) | ((*green as u32) << 8) | (*blue as u32)
             }
-            Self::Pixel(p) => *p,
-        }
+            RGBu32::Pixel(p) => *p,
+        };
+        canvas.put(x, y, val);
+        val
     }
 }


### PR DESCRIPTION
# Design
While writing the `image` example, I realized that I was creating a bunch of different structs with similar functionalities and I started to wonder if I could just integrate all that into `framebrush` itself. I decided that the `Color` trait would be a good candidate for this. I changed its signature and then changed its name to `Draw` to better explain its new functionality. The `.draw` method in `Draw` can either be used to draw shapes or other things or it can be used as a substitute for the `.pixel` method in the old `Color` trait by returning a value of type `T`. For instance, the `Char` struct in the `simple_terminal` example doesn't mutate the `canvas` but returns a `char`. On the other hand, the `ImageSource` type does mutate the `canvas` but it just returns `0` as its return value. Perhas the return value of  `.draw` could be of type `Option<T>` instead of `T` to make the API more usable for types that can't return a default value like `0` as easily. 

# Performance
The old code was technically more efficient while drawing rectangles. The old code could just be copy-pasted to the `.rect` method of `Canvas` instead of using the `Rect` struct with the `Draw` API to circumvent this issue but I currently care more about readable code and performance is far from a top priority.